### PR TITLE
Update Gotop with the latest version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for gotop
 
 # The version of gotop to install.
-gotop_version: 1.4.0
+gotop_version: 3.5.2
 
 # Where to install gotop.
 gotop_installation_path: /usr/local/bin

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,13 @@
 ---
 # vars file for gotop
-gotop_download_url: https://github.com/cjbassi/gotop/releases/download/{{ gotop_version }}/gotop_{{ gotop_version }}_linux_amd64.tgz
+
+go_arch_map:
+  i386: '386'
+  x86_64: 'amd64'
+  aarch64: 'arm64'
+  armv7l: 'arm7'
+  armv6l: 'arm6'
+
+go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
+
+gotop_download_url: https://github.com/xxxserxxx/gotop/releases/download/v{{ gotop_version }}/gotop_v{{ gotop_version }}_{{ ansible_system | lower }}_{{ go_arch }}.tgz


### PR DESCRIPTION
Gotop is no longer maintained (replaced with `ytop`).
However, a fork is still active.

I've also slightly modified the Download URL to support multiple Archs & Systems.